### PR TITLE
fix conditional binding errors

### DIFF
--- a/Eigen/Views/Conversation/ConversationList.swift
+++ b/Eigen/Views/Conversation/ConversationList.swift
@@ -88,14 +88,14 @@ struct ConversationList: View {
                         .padding(.bottom, 0)
                     NavigationLink(destination: PreferencesView(), tag: "preferences", selection: $activeConversation) {
                         if let userIdSplit = matrix.session.myUser?.userId.split(separator: ":") {
-                            let username = userIdSplit[0]
-                            let homeserver = userIdSplit[1]
                             HStack {
                                 UserAvatarView(user: .constant(matrix.session.myUser), height: 18, width: 18)
                                     .environmentObject(RoomData())
                                 HStack(spacing: 0) {
+                                    let username = userIdSplit[0]
                                     Text(username)
                                         .fontWeight(.medium)
+                                    let homeserver = userIdSplit[1]
                                     Text(":" + homeserver)
                                         .fontWeight(.light)
                                 }

--- a/Eigen/Views/Conversation/ConversationList.swift
+++ b/Eigen/Views/Conversation/ConversationList.swift
@@ -87,9 +87,9 @@ struct ConversationList: View {
                         .listStyle(.sidebar)
                         .padding(.bottom, 0)
                     NavigationLink(destination: PreferencesView(), tag: "preferences", selection: $activeConversation) {
-                        if let userIdSplit = matrix.session.myUser?.userId.split(separator: ":"),
-                            let username = userIdSplit[0],
-                            let homeserver = userIdSplit[1] {
+                        if let userIdSplit = matrix.session.myUser?.userId.split(separator: ":") {
+                            let username = userIdSplit[0]
+                            let homeserver = userIdSplit[1]
                             HStack {
                                 UserAvatarView(user: .constant(matrix.session.myUser), height: 18, width: 18)
                                     .environmentObject(RoomData())


### PR DESCRIPTION
This code built in Xcode prior to 14.3 (I don't know which version specifically). But in 14.3, I kept getting the error

`Initializer for conditional binding must have Optional type, not 'String .SubSequence' (aka 'Substring')` on lines 91-92.
It happens that once userIdSplit is calculated it doesn't have any optionals so they don't need to be bound outside of the block. So I moved the username and homeserver inside the block being processed to be
 used later.

 For a block this short, one might get away with simply using the
 userIdSplit values directly but having them named makes the code more
 understandable.