### PR TITLE
Fix room ban event

### DIFF
--- a/Eigen/Views/Conversation/Event/MemberEventView.swift
+++ b/Eigen/Views/Conversation/Event/MemberEventView.swift
@@ -25,7 +25,7 @@ struct MemberEventView: View {
                 case "invite":
                     Text("invited \(event.content["displayname"] as? String ?? "unknown user") to")
                 case "ban":
-                    Text("was banned from")
+                    Text("banned \(event.stateKey ?? "unknown user") (Reason: \(event.wireContent["reason"] as? String ?? "unknown")) from")
                 case "knock":
                     Text("requested to join")
                 default:


### PR DESCRIPTION
Banning in Eigen was showing the banner as the target of being banned: `Administrator was banned from the room`

This now displays
`Administrator banned <target> (Reason: <reason>) from the room`